### PR TITLE
Add Quotes API support (createQuote, confirmQuote)

### DIFF
--- a/src/Glovo/Laas/Client/GlovoConnector.php
+++ b/src/Glovo/Laas/Client/GlovoConnector.php
@@ -23,6 +23,10 @@ use Dots\Glovo\Laas\Client\Requests\Orders\Simulate\SimulateFailedDeliveryReques
 use Dots\Glovo\Laas\Client\Requests\Orders\Simulate\SimulateSuccessfulDeliveryRequest;
 use Dots\Glovo\Laas\Client\Requests\Orders\ValidateOrderRequest;
 use Dots\Glovo\Laas\Client\Requests\Orders\WorkingAreaRequest;
+use Dots\Glovo\Laas\Client\Requests\Quotes\ConfirmQuoteRequest;
+use Dots\Glovo\Laas\Client\Requests\Quotes\CreateQuoteRequest;
+use Dots\Glovo\Laas\Client\Requests\Quotes\DTO\ConfirmQuoteDTO;
+use Dots\Glovo\Laas\Client\Requests\Quotes\DTO\CreateQuoteDTO;
 use Dots\Glovo\Laas\Client\Requests\Webhooks\DeleteWebhookRequest;
 use Dots\Glovo\Laas\Client\Requests\Webhooks\DTO\RegisterWebhookDTO;
 use Dots\Glovo\Laas\Client\Requests\Webhooks\GetWebhooksListRequest;
@@ -35,6 +39,7 @@ use Dots\Glovo\Laas\Client\Responses\OrderCourierContactResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\OrderCourierPositionResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\OrderResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\OrderStatusHistoryResponseDTO;
+use Dots\Glovo\Laas\Client\Responses\QuoteResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\ValidateOrderResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\WebhookResponseDTO;
 use Dots\Glovo\Laas\Client\Responses\WebhooksListResponseDTO;
@@ -84,6 +89,26 @@ class GlovoConnector extends Connector
         $this->authenticateRequests();
 
         return $this->send(new WorkingAreaRequest())->dto();
+    }
+
+    /**
+     * @throws GlovoException
+     */
+    public function createQuote(CreateQuoteDTO $dto): QuoteResponseDTO
+    {
+        $this->authenticateRequests();
+
+        return $this->send(new CreateQuoteRequest($dto))->dto();
+    }
+
+    /**
+     * @throws GlovoException
+     */
+    public function confirmQuote(string $quoteId, ConfirmQuoteDTO $dto): OrderResponseDTO
+    {
+        $this->authenticateRequests();
+
+        return $this->send(new ConfirmQuoteRequest($quoteId, $dto, $this->stageEnv))->dto();
     }
 
     /**

--- a/src/Glovo/Laas/Client/Requests/Quotes/ConfirmQuoteRequest.php
+++ b/src/Glovo/Laas/Client/Requests/Quotes/ConfirmQuoteRequest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Description of ConfirmQuoteRequest.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Requests\Quotes;
+
+use Dots\Glovo\Laas\Client\Requests\PostGlovoRequest;
+use Dots\Glovo\Laas\Client\Requests\Quotes\DTO\ConfirmQuoteDTO;
+use Dots\Glovo\Laas\Client\Responses\OrderResponseDTO;
+use Saloon\Http\Response;
+
+class ConfirmQuoteRequest extends PostGlovoRequest
+{
+    private const ENDPOINT = '/v2/laas/quotes/%s/parcels';
+
+    public function __construct(
+        protected readonly string $quoteId,
+        protected readonly ConfirmQuoteDTO $dto,
+        private readonly bool $stageEnv = true,
+    ) {
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->dto->toRequestData($this->stageEnv);
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf(self::ENDPOINT, $this->quoteId);
+    }
+
+    public function createDtoFromResponse(Response $response): OrderResponseDTO
+    {
+        return OrderResponseDTO::fromResponse($response);
+    }
+}

--- a/src/Glovo/Laas/Client/Requests/Quotes/CreateQuoteRequest.php
+++ b/src/Glovo/Laas/Client/Requests/Quotes/CreateQuoteRequest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Description of CreateQuoteRequest.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Requests\Quotes;
+
+use Dots\Glovo\Laas\Client\Requests\PostGlovoRequest;
+use Dots\Glovo\Laas\Client\Requests\Quotes\DTO\CreateQuoteDTO;
+use Dots\Glovo\Laas\Client\Responses\QuoteResponseDTO;
+use Saloon\Http\Response;
+
+class CreateQuoteRequest extends PostGlovoRequest
+{
+    private const ENDPOINT = '/v2/laas/quotes';
+
+    public function __construct(
+        protected readonly CreateQuoteDTO $dto,
+    ) {
+    }
+
+    protected function defaultBody(): array
+    {
+        return $this->dto->toArray();
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return self::ENDPOINT;
+    }
+
+    public function createDtoFromResponse(Response $response): QuoteResponseDTO
+    {
+        return QuoteResponseDTO::fromResponse($response);
+    }
+}

--- a/src/Glovo/Laas/Client/Requests/Quotes/DTO/ConfirmQuoteDTO.php
+++ b/src/Glovo/Laas/Client/Requests/Quotes/DTO/ConfirmQuoteDTO.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Description of ConfirmQuoteDTO.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Requests\Quotes\DTO;
+
+use Dots\Data\DTO;
+use Dots\Glovo\Laas\Client\Resources\Contact;
+use Dots\Glovo\Laas\Client\Resources\Order\OrderPrice;
+use Dots\Glovo\Laas\Client\Resources\Order\PackageDetails;
+use Dots\Glovo\Laas\Client\Resources\Quotes\QuoteDeliveryAddress;
+
+class ConfirmQuoteDTO extends DTO
+{
+    protected Contact $contact;
+
+    protected ?PackageDetails $packageDetails;
+
+    protected ?OrderPrice $price;
+
+    protected ?string $pickupOrderCode;
+
+    protected ?QuoteDeliveryAddress $deliveryAddress;
+
+    public function toRequestData(bool $stageEnv): array
+    {
+        $data = $this->toArray();
+        if ($stageEnv) {
+            $data['price'] = null;
+        }
+
+        return $data;
+    }
+
+    public function getContact(): Contact
+    {
+        return $this->contact;
+    }
+
+    public function getPackageDetails(): ?PackageDetails
+    {
+        return $this->packageDetails;
+    }
+
+    public function getPrice(): ?OrderPrice
+    {
+        return $this->price;
+    }
+
+    public function getPickupOrderCode(): ?string
+    {
+        return $this->pickupOrderCode;
+    }
+
+    public function getDeliveryAddress(): ?QuoteDeliveryAddress
+    {
+        return $this->deliveryAddress;
+    }
+}

--- a/src/Glovo/Laas/Client/Requests/Quotes/DTO/CreateQuoteDTO.php
+++ b/src/Glovo/Laas/Client/Requests/Quotes/DTO/CreateQuoteDTO.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Description of CreateQuoteDTO.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Requests\Quotes\DTO;
+
+use Dots\Data\DTO;
+use Dots\Glovo\Laas\Client\Resources\Quotes\QuoteDeliveryAddress;
+use Dots\Glovo\Laas\Client\Resources\Quotes\QuotePickupDetails;
+
+class CreateQuoteDTO extends DTO
+{
+    protected QuotePickupDetails $pickupDetails;
+
+    protected QuoteDeliveryAddress $deliveryAddress;
+
+    public function getPickupDetails(): QuotePickupDetails
+    {
+        return $this->pickupDetails;
+    }
+
+    public function getDeliveryAddress(): QuoteDeliveryAddress
+    {
+        return $this->deliveryAddress;
+    }
+}

--- a/src/Glovo/Laas/Client/Resources/Quotes/AddressBook.php
+++ b/src/Glovo/Laas/Client/Resources/Quotes/AddressBook.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Description of AddressBook.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Resources\Quotes;
+
+use Dots\Data\DTO;
+
+class AddressBook extends DTO
+{
+    protected string $id;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Glovo/Laas/Client/Resources/Quotes/EstimatedTimeOfDelivery.php
+++ b/src/Glovo/Laas/Client/Resources/Quotes/EstimatedTimeOfDelivery.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Description of EstimatedTimeOfDelivery.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Resources\Quotes;
+
+use Dots\Data\DTO;
+
+class EstimatedTimeOfDelivery extends DTO
+{
+    protected ?string $lowerBound;
+
+    protected ?string $upperBound;
+
+    protected ?string $deliveryDuration;
+
+    public function getLowerBound(): ?string
+    {
+        return $this->lowerBound;
+    }
+
+    public function getUpperBound(): ?string
+    {
+        return $this->upperBound;
+    }
+
+    public function getDeliveryDuration(): ?string
+    {
+        return $this->deliveryDuration;
+    }
+}

--- a/src/Glovo/Laas/Client/Resources/Quotes/QuoteDeliveryAddress.php
+++ b/src/Glovo/Laas/Client/Resources/Quotes/QuoteDeliveryAddress.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Description of QuoteDeliveryAddress.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Resources\Quotes;
+
+use Dots\Data\DTO;
+use Dots\Glovo\Laas\Client\Resources\Coordinates;
+
+class QuoteDeliveryAddress extends DTO
+{
+    protected string $rawAddress;
+
+    protected ?Coordinates $coordinates;
+
+    protected ?string $details;
+
+    public function getRawAddress(): string
+    {
+        return $this->rawAddress;
+    }
+
+    public function getCoordinates(): ?Coordinates
+    {
+        return $this->coordinates;
+    }
+
+    public function getDetails(): ?string
+    {
+        return $this->details;
+    }
+}

--- a/src/Glovo/Laas/Client/Resources/Quotes/QuotePickupDetails.php
+++ b/src/Glovo/Laas/Client/Resources/Quotes/QuotePickupDetails.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Description of QuotePickupDetails.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Resources\Quotes;
+
+use Dots\Data\DTO;
+use Dots\Glovo\Laas\Client\Resources\GlovoDateTime;
+
+class QuotePickupDetails extends DTO
+{
+    protected AddressBook $addressBook;
+
+    protected ?GlovoDateTime $pickupTime;
+
+    public static function fromArray(array $data): static
+    {
+        $data['addressBook'] = AddressBook::fromArray($data['addressBook']);
+        $data['pickupTime'] = isset($data['pickupTime']) ? GlovoDateTime::fromString($data['pickupTime']) : null;
+
+        return parent::fromArray($data);
+    }
+
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['pickupTime'] = $this->getPickupTime()?->__toString();
+
+        return $data;
+    }
+
+    public function getAddressBook(): AddressBook
+    {
+        return $this->addressBook;
+    }
+
+    public function getPickupTime(): ?GlovoDateTime
+    {
+        return $this->pickupTime;
+    }
+}

--- a/src/Glovo/Laas/Client/Responses/QuoteResponseDTO.php
+++ b/src/Glovo/Laas/Client/Responses/QuoteResponseDTO.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Description of QuoteResponseDTO.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dots\Glovo\Laas\Client\Responses;
+
+use Dots\Glovo\Laas\Client\Resources\Quotes\EstimatedTimeOfDelivery;
+use Dots\Glovo\Laas\Client\Resources\Quotes\QuoteDeliveryAddress;
+use Dots\Glovo\Laas\Client\Resources\Quotes\QuotePickupDetails;
+
+class QuoteResponseDTO extends GlovoResponseDTO
+{
+    protected string $quoteId;
+
+    protected float $quotePrice;
+
+    protected string $currencyCode;
+
+    protected string $createdAt;
+
+    protected string $expiresAt;
+
+    protected ?QuotePickupDetails $pickupDetails;
+
+    protected ?QuoteDeliveryAddress $deliveryAddress;
+
+    protected ?EstimatedTimeOfDelivery $estimatedTimeOfDelivery;
+
+    public static function fromArray(array $data): static
+    {
+        $data['pickupDetails'] = isset($data['pickupDetails'])
+            ? QuotePickupDetails::fromArray($data['pickupDetails'])
+            : null;
+        $data['deliveryAddress'] = isset($data['deliveryAddress'])
+            ? QuoteDeliveryAddress::fromArray($data['deliveryAddress'])
+            : null;
+        $data['estimatedTimeOfDelivery'] = isset($data['estimatedTimeOfDelivery'])
+            ? EstimatedTimeOfDelivery::fromArray($data['estimatedTimeOfDelivery'])
+            : null;
+
+        return parent::fromArray($data);
+    }
+
+    public function getQuoteId(): string
+    {
+        return $this->quoteId;
+    }
+
+    public function getQuotePrice(): float
+    {
+        return $this->quotePrice;
+    }
+
+    public function getCurrencyCode(): string
+    {
+        return $this->currencyCode;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function getExpiresAt(): string
+    {
+        return $this->expiresAt;
+    }
+
+    public function getPickupDetails(): ?QuotePickupDetails
+    {
+        return $this->pickupDetails;
+    }
+
+    public function getDeliveryAddress(): ?QuoteDeliveryAddress
+    {
+        return $this->deliveryAddress;
+    }
+
+    public function getEstimatedTimeOfDelivery(): ?EstimatedTimeOfDelivery
+    {
+        return $this->estimatedTimeOfDelivery;
+    }
+}


### PR DESCRIPTION
Add SDK methods for Glovo LaaS Quotes API:
- POST /v2/laas/quotes (fare estimation)
- POST /v2/laas/quotes/{quoteId}/parcels (quote confirmation)